### PR TITLE
Add a combat status indicator

### DIFF
--- a/AuraIndicators.lua
+++ b/AuraIndicators.lua
@@ -413,6 +413,13 @@ function EnhancedRaidFrames:QueryAuraInfo(auraName, unit)
 		end
 	end
 
+	-- Check if we want to show combat flag
+	if auraName:upper() == "COMBAT" then
+		if UnitAffectingCombat(unit) then
+			return true, "Interface\\Icons\\Ability_Dualwield", 0, 0, 0, "", "player"
+		end
+	end
+
 	-- Check if we want to show ToT flag
 	if auraName:upper() == "TOT" then
 		if UnitIsUnit(unit, "targettarget") then

--- a/GUI/IndicatorConfigPanel.lua
+++ b/GUI/IndicatorConfigPanel.lua
@@ -72,6 +72,7 @@ function EnhancedRaidFrames:CreateIndicatorOptions()
 						self.BROWN_COLOR:WrapTextInColorCode("Disease")..self.WHITE_COLOR:WrapTextInColorCode(": "..L["diseaseWildcard_desc"]).."\n"..
 						self.BLUE_COLOR:WrapTextInColorCode("Magic")..self.WHITE_COLOR:WrapTextInColorCode(": "..L["magicWildcard_desc"]).."\n"..
 						self.RED_COLOR:WrapTextInColorCode("PvP")..self.WHITE_COLOR:WrapTextInColorCode(": "..L["pvpWildcard_desc"]).."\n"..
+						self.RED_COLOR:WrapTextInColorCode("Combat")..self.WHITE_COLOR:WrapTextInColorCode(": "..L["combatWildcard_desc"]).."\n"..
 						self.RED_COLOR:WrapTextInColorCode("ToT")..self.WHITE_COLOR:WrapTextInColorCode(": "..L["totWildcard_desc"]).."\n",
 				multiline = 5,
 				get = function() return self.db.profile[i].auras end,

--- a/Localizations/enUS.lua
+++ b/Localizations/enUS.lua
@@ -140,6 +140,7 @@ L["curseWildcard_desc"] = "any curse debuffs"
 L["diseaseWildcard_desc"] = "any disease debuffs"
 L["magicWildcard_desc"] = "any magic debuffs"
 L["pvpWildcard_desc"] = "if the unit is PvP flagged"
+L["combatWildcard_desc"] = "if the unit is combat flagged"
 L["totWildcard_desc"] = "if the unit is the target of target"
 
 L["Visibility and Behavior"] = true


### PR DESCRIPTION
Useful for example in PvP to see who could be Sapped by an enemy Rogue,
or has dropped combat and could drink for mana.