### PR TITLE
ERF - QvantryEdit: Here is the PR I contacted you about, sorry for the size of it :S

### DIFF
--- a/AuraIndicators.lua
+++ b/AuraIndicators.lua
@@ -2,17 +2,221 @@
 -- Copyright (c) 2017-2021 Britt W. Yazel
 -- This code is licensed under the MIT license (see LICENSE for details)
 
+-- TODO: Covert strings to ids and cache it
+-- Probably want to move to adding spell ids over spell names in the interface with the possibility of inputing names that are converted to ids on the spot?
+-- This way we can avoid all string matching, and some buffs/debuffs have the same name but not same spell ids, guardian berserk & feral berserk for instance.
+
 local _, addonTable = ...
 local EnhancedRaidFrames = addonTable.EnhancedRaidFrames
 
 local media = LibStub:GetLibrary("LibSharedMedia-3.0")
-local unitAuras = {} -- Matrix to keep a list of all auras on all units
+local unitAuras = {}
+local unitDebuffs = {}
 
 EnhancedRaidFrames.iconCache = {}
 EnhancedRaidFrames.iconCache["poison"] = 132104
 EnhancedRaidFrames.iconCache["disease"] = 132099
 EnhancedRaidFrames.iconCache["curse"] = 132095
 EnhancedRaidFrames.iconCache["magic"] = 135894
+
+EnhancedRaidFrames.debug = false
+
+local unitStates = {}
+
+local dispels = {}
+dispels.magic = {
+	32375, -- Mass Dispell
+}
+
+dispels.magicPet = {
+	89808, -- Singe Magic
+}
+
+dispels.curse = {
+	2782, -- Remove Corruption
+	374251, -- Cauterizing Flame
+	51886, -- Cleanse Spirit
+	475, -- Remove Curse
+}
+dispels.disease = {
+	213634, -- Purify Disease
+	374251, -- Cauterizing Flame
+	213644, -- Cleanse Toxins
+	218164, -- Detox
+}
+
+dispels.poison = {
+	2782, -- Remove Corruption
+	360823, -- Naturalize
+	365585, -- Expunge
+	374251, -- Cauterizing Flame
+	213644, -- Cleanse Toxins
+	218164, -- Detox
+}
+
+-- We cannot check talents with IsSpellKnown, a lot of healers have improved dispel talents
+-- which enables them to dispel more debuff types. So we need to check the talents for those types.
+dispelImprovements = {}
+dispelImprovements.curse = {
+	392378, -- Improved Nature's Cure
+	383016, -- Improved Purify Spirit
+}
+
+dispelImprovements.disease = {
+	390632, -- Improved Purify
+	393024, -- Improved Cleanse
+	388874, -- Improved Detox
+}
+
+dispelImprovements.poison = {
+	392378, -- Improved Nature's Cure
+	393024, -- Improved Cleanse
+	388874, -- Improved Detox
+}
+
+healerSpecializations = {
+	[2] = { 1 }, -- Paladin, Holy
+	[5] = { 1, 2 }, -- Priest, Discipline + Holy
+	[7] = { 3 }, -- Shaman, Restoration
+	[10] = { 2 }, -- Monk, Mistweaver
+	[11] = { 4 }, -- Druid, Restoration
+	[13] = { 2 } -- Evoker, Preservation
+}
+
+local canDispellMagic = false
+local canDispellCurse = false
+local canDispellDisease = false
+local canDispellPoison = false
+
+function EnhancedRaidFrames:InitDispels()
+	self:UpdateCanDispell()
+end
+
+function EnhancedRaidFrames:UpdateCanDispell()
+	canDispelMagic = self:CanDispelType(dispels.magic, false)
+	canDispelCurse = self:CanDispelType(dispels.curse, false)
+	canDispelDisease = self:CanDispelType(dispels.disease, false)
+	canDispelPoison = self:CanDispelType(dispels.poison, false)
+
+	-- The only reason for this approach for healers rather than just adding their dispels to magic table is because
+	-- IsSpellKnown returns False for Naturalize for some reason even though it is not a talent. So the frames wouldn't highlight when playing an Evoker.
+	if not canDispelMagic then
+		canDispelMagic = self:IsHealer()
+	end
+
+	local learnedTalents = self:LoopNodes()
+	canDispelCurse = EnhancedRaidFrames:CanDispelTypeFromTalentPoints(dispelImprovements.curse, learnedTalents, canDispelCurse)
+	canDispelDisease = EnhancedRaidFrames:CanDispelTypeFromTalentPoints(dispelImprovements.disease, learnedTalents, canDispelDisease)
+	canDispelPoison = EnhancedRaidFrames:CanDispelTypeFromTalentPoints(dispelImprovements.poison, learnedTalents, canDispelPoison)
+end
+
+function EnhancedRaidFrames:IsHealer()
+	local currentClassId = select(3, UnitClass("player"))
+
+	if not self:IsHealerClass(currentClassId) then
+		return false
+	end
+
+	if not self:IsHealerSpecialization(currentClassId) then
+		return false
+	end
+
+	return true
+end
+
+function EnhancedRaidFrames:IsHealerClass(currentClassId)
+	return healerSpecializations[currentClassId] ~= nil
+end
+
+function EnhancedRaidFrames:IsHealerSpecialization(currentClassId)
+	local currentClass = healerSpecializations[currentClassId]
+	local currentSpecialization = GetSpecialization()
+
+	for i = 1, #currentClass do
+		if currentClass[i] == currentSpecialization then
+			return true
+		end
+	end
+
+	return false
+end
+
+function EnhancedRaidFrames:CanDispelType(spells, isPetSpell)
+	for i = 1, #spells do
+		if IsSpellKnown(spells[i], isPetSpell) then
+			return true
+		end
+	end
+
+	return false
+end
+
+function EnhancedRaidFrames:CanDispelTypeFromTalentPoints(spells, learnedTalents, canDispelType)
+	if canDispelType then
+		return true
+	end
+
+	for i = 1, #spells do
+		if learnedTalents[spells[i]] ~= nil then
+			return true
+		end
+	end
+
+	return false
+end
+
+function PrintSupportedDispels()
+	PrintSpecificSupportedDispelType(canDispelMagic, "Magic")
+	PrintSpecificSupportedDispelType(canDispelCurse, "Curse")
+	PrintSpecificSupportedDispelType(canDispelDisease, "Disease")
+	PrintSpecificSupportedDispelType(canDispelPoison, "Poison")
+end
+
+function PrintSpecificSupportedDispelType(canDispelType, typeName)
+	if canDispelType then
+		print(typeName .. ": true")
+	else
+		print(typeName .. ": false")
+	end
+end
+
+function EnhancedRaidFrames:LoopNodes()
+	local list = {}
+
+	local configId = C_ClassTalents.GetActiveConfigID()
+	if configId == nil then
+		return
+	end
+
+	local configInfo = C_Traits.GetConfigInfo(configId)
+	if configInfo == nil then
+		return
+	end
+
+	for _, treeId in ipairs(configInfo.treeIDs) do
+
+		local nodes = C_Traits.GetTreeNodes(treeId)
+		for i, nodeId in ipairs(nodes) do
+
+			nodeInfo = C_Traits.GetNodeInfo(configId, nodeId)
+			-- Explicitly check for 1 rather than > 0 since all improved dispels are one pointers
+			-- this way we can ignore some of the search
+			if nodeInfo.ranksPurchased == 1 then
+				for _, entryId in ipairs(nodeInfo.entryIDs) do
+					local entryInfo = C_Traits.GetEntryInfo(configId, entryId)
+					if entryInfo and entryInfo.definitionID then
+						local definitionInfo = C_Traits.GetDefinitionInfo(entryInfo.definitionID)
+						if definitionInfo.spellID then
+							list[definitionInfo.spellID] = entryInfo.definitionID
+						end
+					end
+				end
+			end
+		end
+	end
+
+	return list
+end
 
 -------------------------------------------------------------------------
 -------------------------------------------------------------------------
@@ -34,31 +238,49 @@ end
 -- Create the FontStrings used for indicators
 function EnhancedRaidFrames:CreateIndicators(frame)
 	frame.ERFIndicators = {}
-
 	-- Create indicators
 	for i = 1, 9 do
-		--I'm not sure if this is ever the case, but to stop us from creating redundant frames we should try to re-capture them when possible
-		--On the global table, our frames our named "CompactRaidFrame#" + "ERFIndicator" + index#, i.e. "CompactRaidFrame1ERFIndicator1"
-		if not _G[frame:GetName().."ERFIndicator"..i] then
-			--We have to use CompactAuraTemplate to allow for our clicks to be passed through, otherwise our frames won't allow selecting the raid frame behind it
-			frame.ERFIndicators[i] = CreateFrame("Button", frame:GetName().."ERFIndicator"..i, frame, "ERFIndicatorTemplate")
-		else
-			frame.ERFIndicators[i] =  _G[frame:GetName().."ERFIndicator"..i]
-			frame.ERFIndicators[i]:SetParent(frame) --if we capture an old indicator frame, we should reattach it to the current unit frame
+		if self.db.profile[i].numIcons == nil then
+			self.db.profile[i].numIcons = 1
 		end
 
-		--create local pointer for readability
-		local indicatorFrame = frame.ERFIndicators[i]
+		numAuras = self.db.profile[i].numIcons
 
-		--mark the position of this particular frame for use later (i.e. 1->9)
-		indicatorFrame.position = i
+		local auras = {}
+		for j = 1, numAuras do
+			local indicatorFrame = nil
+			local stacksFrame = nil
 
-		--hook OnEnter and OnLeave for showing and hiding ability tooltips
-		indicatorFrame:SetScript("OnEnter", function() self:Tooltip_OnEnter(indicatorFrame) end)
-		indicatorFrame:SetScript("OnLeave", function() GameTooltip:Hide() end)
+			--I'm not sure if this is ever the case, but to stop us from creating redundant frames we should try to re-capture them when possible
+			--On the global table, our frames our named "CompactRaidFrame#" + "ERFIndicator" + index#, i.e. "CompactRaidFrame1ERFIndicator1"
+			frameName = frame:GetName().."ERFIndicator"..i..j
+			if not _G[frame:GetName().."ERFIndicator"..i] then
+				--We have to use CompactAuraTemplate to allow for our clicks to be passed through, otherwise our frames won't allow selecting the raid frame behind it
+				indicatorFrame = CreateFrame("Button", frameName, frame, "ERFIndicatorTemplate")
 
-		--disable the mouse click on our frames to allow those clicks to get passed straight through to the raid frame behind (switch target, right click, etc)
-		indicatorFrame:SetMouseClickEnabled(false) --this MUST come after the SetScript lines for OnEnter and OnLeave. SetScript will re-enable mouse clicks when called.
+				if self.db.profile[i].showStacks then
+					indicatorFrame.stacksText = indicatorFrame:CreateFontString(nil, "OVERLAY", "GameTooltipText")
+					indicatorFrame.stacksText:SetPoint("TOPRIGHT", 3, 3)
+				end
+			else
+				indicatorFrame = frameName
+				indicatorFrame:SetParent(frame) --if we capture an old indicator frame, we should reattach it to the current unit frame
+			end
+
+			--mark the position of this particular frame for use later (i.e. 1->9)
+			indicatorFrame.position = i
+
+			--hook OnEnter and OnLeave for showing and hiding ability tooltips
+			indicatorFrame:SetScript("OnEnter", function() self:Tooltip_OnEnter(indicatorFrame) end)
+			indicatorFrame:SetScript("OnLeave", function() GameTooltip:Hide() end)
+
+			--disable the mouse click on our frames to allow those clicks to get passed straight through to the raid frame behind (switch target, right click, etc)
+			indicatorFrame:SetMouseClickEnabled(false) --this MUST come after the SetScript lines for OnEnter and OnLeave. SetScript will re-enable mouse clicks when called.
+
+			table.insert(auras, indicatorFrame)
+		end
+
+		frame.ERFIndicators[i] = auras
 	end
 
 	--override for a change made in 9.2 which broke muscle memory for lots of healers
@@ -77,66 +299,95 @@ function EnhancedRaidFrames:SetIndicatorAppearance(frame)
 
 	for i = 1, 9 do
 		--create local pointer for readability
-		local indicatorFrame = frame.ERFIndicators[i]
+		local auras = frame.ERFIndicators[i]
+		for j = 1, #auras do
+			indicatorFrame = auras[j]
 
-		--set icon size
-		indicatorFrame:SetWidth(self.db.profile[i].indicatorSize)
-		indicatorFrame:SetHeight(self.db.profile[i].indicatorSize)
+			--set icon size
+			local iconSize = self.db.profile[i].indicatorSize
+			indicatorFrame:SetWidth(iconSize)
+			indicatorFrame:SetHeight(iconSize)
 
-		--------------------------------------
+			--------------------------------------
 
-		--set indicator frame position
-		local PAD = 1
-		local iconVerticalOffset = floor(self.db.profile[i].indicatorVerticalOffset * frame:GetHeight()) --round down
-		local iconHorizontalOffset = floor(self.db.profile[i].indicatorHorizontalOffset * frame:GetWidth()) --round down
+			--set indicator frame position
+			local PAD = 1
+			local iconVerticalOffset = floor(self.db.profile[i].indicatorVerticalOffset * frame:GetHeight()) --round down
+			local iconHorizontalOffset = floor(self.db.profile[i].indicatorHorizontalOffset * frame:GetWidth())--round down
 
-		--we probably don't want to overlap the power bar (rage, mana, energy, etc) so we need a compensation factor
-		local powerBarVertOffset
-		if self.db.profile.powerBarOffset and frame.powerBar:IsShown() then
-			powerBarVertOffset = frame.powerBar:GetHeight() + 2 --add 2 to not overlap the powerBar border
-		else
-			powerBarVertOffset = 0
+			if self.db.profile[i].numIcons > 1 then
+				growthDirection = self.db.profile[i].growthDirection
+				local multiplier = 0
+				if growthDirection ~= nil then
+					if growthDirection == 1 then -- Left
+						multiplier = (j - 1) * -1
+					elseif growthDirection == 2 and #auras > 1 then -- Centered
+						-- no need to do anything cause if it's centered it gets dynamically updated. See UpdatePosition
+					elseif growthDirection == 3 then -- Right
+						multiplier = j - 1
+					end
+				end
+
+				iconHorizontalOffset = iconHorizontalOffset + multiplier * iconSize
+			end
+
+			--we probably don't want to overlap the power bar (rage, mana, energy, etc) so we need a compensation factor
+			local powerBarVertOffset
+			if self.db.profile.powerBarOffset and frame.powerBar:IsShown() then
+				powerBarVertOffset = frame.powerBar:GetHeight() + 2 --add 2 to not overlap the powerBar border
+			else
+				powerBarVertOffset = 0
+			end
+
+			indicatorFrame:ClearAllPoints()
+			if i == 1 then
+				indicatorFrame:SetPoint("TOPLEFT", frame, "TOPLEFT", PAD + iconHorizontalOffset, -PAD + iconVerticalOffset)
+			elseif i == 2 then
+				indicatorFrame:SetPoint("TOP", frame, "TOP", 0 + iconHorizontalOffset, -PAD + iconVerticalOffset)
+			elseif i == 3 then
+				indicatorFrame:SetPoint("TOPRIGHT", frame, "TOPRIGHT", -PAD + iconHorizontalOffset, -PAD + iconVerticalOffset)
+			elseif i == 4 then
+				indicatorFrame:SetPoint("LEFT", frame, "LEFT", PAD + iconHorizontalOffset, 0 + iconVerticalOffset + powerBarVertOffset/2)
+			elseif i == 5 then
+				indicatorFrame:SetPoint("CENTER", frame, "CENTER", 0 + iconHorizontalOffset, 0 + iconVerticalOffset + powerBarVertOffset/2)
+			elseif i == 6 then
+				indicatorFrame:SetPoint("RIGHT", frame, "RIGHT", -PAD + iconHorizontalOffset, 0 + iconVerticalOffset + powerBarVertOffset/2)
+			elseif i == 7 then
+				indicatorFrame:SetPoint("BOTTOMLEFT", frame, "BOTTOMLEFT", PAD + iconHorizontalOffset, PAD + iconVerticalOffset + powerBarVertOffset)
+			elseif i == 8 then
+				indicatorFrame:SetPoint("BOTTOM", frame, "BOTTOM", 0 + iconHorizontalOffset, PAD + iconVerticalOffset + powerBarVertOffset)
+			elseif i == 9 then
+				indicatorFrame:SetPoint("BOTTOMRIGHT", frame, "BOTTOMRIGHT", -PAD + iconHorizontalOffset, PAD + iconVerticalOffset + powerBarVertOffset)
+			end
+
+			--------------------------------------
+
+			--set font size, shape, font, and switch our text object
+			indicatorFrame.Text:SetText("") --clear previous text
+			local font = (media and media:Fetch('font', self.db.profile.indicatorFont)) or STANDARD_TEXT_FONT
+
+			indicatorFrame.Text:SetFont(font, self.db.profile[i].textSize, "OUTLINE")
+			if indicatorFrame.stacksText then
+				indicatorFrame.stacksText:SetFont(font, self.db.profile[i].textSize, "OUTLINE")
+				indicatorFrame.stacksText:SetTextColor(self.YELLOW_COLOR:GetRGB())
+			end
+
+			--switch the parent for our text frame to keep the text on top of the cooldown animation
+			if self.db.profile[i].showCountdownSwipe then
+				indicatorFrame.Text:SetParent(indicatorFrame.Cooldown)
+
+				if indicatorFrame.stacksText then
+					indicatorFrame.stacksText:SetParent(indicatorFrame.Cooldown)
+				end
+			else
+				indicatorFrame.Text:SetParent(indicatorFrame)
+			end
+
+			--clear any animations
+			ActionButton_HideOverlayGlow(indicatorFrame)
+			CooldownFrame_Clear(indicatorFrame.Cooldown)
+			indicatorFrame.Icon:SetAlpha(1)
 		end
-
-		indicatorFrame:ClearAllPoints()
-		if i == 1 then
-			indicatorFrame:SetPoint("TOPLEFT", frame, "TOPLEFT", PAD + iconHorizontalOffset, -PAD + iconVerticalOffset)
-		elseif i == 2 then
-			indicatorFrame:SetPoint("TOP", frame, "TOP", 0 + iconHorizontalOffset, -PAD + iconVerticalOffset)
-		elseif i == 3 then
-			indicatorFrame:SetPoint("TOPRIGHT", frame, "TOPRIGHT", -PAD + iconHorizontalOffset, -PAD + iconVerticalOffset)
-		elseif i == 4 then
-			indicatorFrame:SetPoint("LEFT", frame, "LEFT", PAD + iconHorizontalOffset, 0 + iconVerticalOffset + powerBarVertOffset/2)
-		elseif i == 5 then
-			indicatorFrame:SetPoint("CENTER", frame, "CENTER", 0 + iconHorizontalOffset, 0 + iconVerticalOffset + powerBarVertOffset/2)
-		elseif i == 6 then
-			indicatorFrame:SetPoint("RIGHT", frame, "RIGHT", -PAD + iconHorizontalOffset, 0 + iconVerticalOffset + powerBarVertOffset/2)
-		elseif i == 7 then
-			indicatorFrame:SetPoint("BOTTOMLEFT", frame, "BOTTOMLEFT", PAD + iconHorizontalOffset, PAD + iconVerticalOffset + powerBarVertOffset)
-		elseif i == 8 then
-			indicatorFrame:SetPoint("BOTTOM", frame, "BOTTOM", 0 + iconHorizontalOffset, PAD + iconVerticalOffset + powerBarVertOffset)
-		elseif i == 9 then
-			indicatorFrame:SetPoint("BOTTOMRIGHT", frame, "BOTTOMRIGHT", -PAD + iconHorizontalOffset, PAD + iconVerticalOffset + powerBarVertOffset)
-		end
-
-		--------------------------------------
-
-		--set font size, shape, font, and switch our text object
-		indicatorFrame.Text:SetText("") --clear previous text
-		local font = (media and media:Fetch('font', self.db.profile.indicatorFont)) or STANDARD_TEXT_FONT
-		indicatorFrame.Text:SetFont(font, self.db.profile[i].textSize, "OUTLINE")
-
-		--switch the parent for our text frame to keep the text on top of the cooldown animation
-		if not self.db.profile[i].showCountdownSwipe then
-			indicatorFrame.Text:SetParent(indicatorFrame)
-		else
-			indicatorFrame.Text:SetParent(indicatorFrame.Cooldown)
-		end
-
-		--clear any animations
-		ActionButton_HideOverlayGlow(indicatorFrame)
-		CooldownFrame_Clear(indicatorFrame.Cooldown)
-		indicatorFrame.Icon:SetAlpha(1)
 	end
 end
 
@@ -151,6 +402,7 @@ function EnhancedRaidFrames:UpdateIndicators(frame, setAppearance)
 	--Normal raid members have frame.unit that says "Raid1", "Raid5", etc.
 	--We don't want to put icons over these tiny little target and target of target bars
 	--Also, in 8.2.5 blizzard unified the nameplate code with the raid frame code. Don't display icons on nameplates
+
 	if not frame.unit
 			or string.find(frame.unit, "target")
 			or string.find(frame.unit, "nameplate")
@@ -174,25 +426,316 @@ function EnhancedRaidFrames:UpdateIndicators(frame, setAppearance)
 	-- Update unit auras
 	self:UpdateUnitAuras(frame.unit)
 
-	-- Loop over all 9 indicators and process them individually
-	for i = 1, 9 do
-		--create local pointer for readability
-		local indicatorFrame = frame.ERFIndicators[i]
+	self:UpdateUnitState(frame)
 
-		-- this is the meat of our processing loop
-		self:ProcessIndicator(indicatorFrame, frame.unit)
+	-- TODO: Remove the assumption that we have 9 indicators.
+	-- Start with 0 indicators and let the users add an indicator and position it.
+	-- Now that we have dynamic aura groups in an indicator, there is probably zero need for 9 indicators.
+	local raidRequirement = 5
+	local isInRaid = GetNumGroupMembers() > raidRequirement
+	for i = 1, 9 do
+		local auraNames = self.auraStrings[i]
+		local auras = frame.ERFIndicators[i]
+		local shouldShowAuras = true
+		local currProfile = self.db.profile[i]
+
+		if self.db.profile[i].disableInRaid and isInRaid then
+			shouldShowAuras = false
+		end
+
+		if shouldShowAuras then
+			local shouldCopyTable
+			auraNames, shouldCopyTable = self:TryApplyGeneralDebuffsSettings(self.db.profile[i].showGeneralDebuffs, auraNames, frame.unit)
+			local auraNamesToUse = nil
+			if shouldCopyTable then
+				auraNamesToUse = GetTableCopy(auraNames)
+			else
+				auraNamesToUse = auraNames
+			end
+
+			frame.ERFIndicators[i].numVisibleAuras = 0
+			for j = 1, #auras do
+				--create local pointer for readability
+				local indicatorFrame = auras[j]
+				indicatorFrame:Show()
+
+				-- this is the meat of our processing loop
+				self:ProcessIndicator(indicatorFrame, frame, auraNamesToUse, i)
+			end
+
+			self:TryUpdateCenteredDynamicGroupsPosition(self.db.profile[i].growthDirection, self.db.profile[i].numIcons, self.db.profile[i].numVisibleAuras)
+		else
+			for j = 1, #auras do
+				--create local pointer for readability
+				local indicatorFrame = auras[j]
+				indicatorFrame:Hide()
+			end
+		end
 	end
 end
 
+function EnhancedRaidFrames:TryApplyGeneralDebuffsSettings(shouldShowGeneralDebuffs, auraNames, unit)
+	if not shouldShowGeneralDebuffs then
+		return auraNames, true
+	end
+
+	local debuffs = GetTableCopy(unitDebuffs[unit])
+
+	-- Sort table so debuffs with lowest remaining duration are prioritized
+	table.sort(debuffs, CompareExpirationTime)
+
+	-- remove blacklisted auras from the table
+	for k, v in pairs(debuffs) do
+		for j = 1, #auraNames do
+			if debuffs[k].name == auraNames[j] then
+				debuffs[k] = nil
+				break
+			end
+		end
+	end
+
+	-- replace auras with the debuffs table
+	auraNames = {}
+	for k, v in pairs(debuffs) do
+		auraNames[k] = debuffs[k].name
+	end
+
+	return auraNames, false
+end
+
+function EnhancedRaidFrames:TryUpdateCenteredDynamicGroupsPosition(growthDirection, numIcons, numVisibleAuras)
+	local growthDirectionCentered = growthDirection == 2
+	local shouldUpdate = numIcons < 1 and growthDirectionCentered
+	if not shouldUpdate then
+		return
+	end
+
+	local numVisibleAuras = numVisibleAuras
+	for j = 1, numVisibleAuras do
+		--create local pointer for readability
+		local indicatorFrame = auras[j]
+
+		self:UpdatePosition(frame, indicatorFrame, numVisibleAuras, i, j)
+	end
+end
+
+function GetTableCopy(t)
+  local tableCopy = { }
+  for k, v in pairs(t) do
+		tableCopy[k] = v
+	end
+
+  return tableCopy
+end
+
+
+function CompareExpirationTime(auraA, auraB)
+	return GetExpirationTime(auraA) < GetExpirationTime(auraB)
+end
+
+function GetExpirationTime(aura)
+	-- Auras with expiration time of 0 don't expire ever, they're infinite, just make them expire in an absurdly long time
+	if aura.expirationTime == 0 then
+		return 999999999999999
+	end
+
+	return aura.expirationTime
+end
+
+function EnhancedRaidFrames:UpdatePosition(frame, indicatorFrame, numVisibleAuras, groupIndex, auraIndex)
+	--set indicator frame position
+	local PAD = 1
+	local iconVerticalOffset = floor(self.db.profile[groupIndex].indicatorVerticalOffset * frame:GetHeight()) --round down
+	local iconHorizontalOffset = floor(self.db.profile[groupIndex].indicatorHorizontalOffset * frame:GetWidth())--round down
+
+	local iconSize = self.db.profile[groupIndex].indicatorSize
+	local iconHalfSize = iconSize * 0.5
+	local totalWidth = iconSize * numVisibleAuras
+	local halfWidth = totalWidth * 0.5
+
+	iconHorizontalOffset = iconHorizontalOffset - halfWidth + iconHalfSize
+	multiplier = auraIndex - 1
+	iconHorizontalOffset = iconHorizontalOffset + multiplier * iconSize
+
+	--we probably don't want to overlap the power bar (rage, mana, energy, etc) so we need a compensation factor
+	local powerBarVertOffset
+	if self.db.profile.powerBarOffset and frame.powerBar:IsShown() then
+		powerBarVertOffset = frame.powerBar:GetHeight() + 2 --add 2 to not overlap the powerBar border
+	else
+		powerBarVertOffset = 0
+	end
+
+	-- This will get improved if I change so that we don't assume that we have 9 indicators and let the users create indicators based on their needs (that's destructive to their user profiles though)
+	indicatorFrame:ClearAllPoints()
+	if groupIndex == 1 then
+		indicatorFrame:SetPoint("TOPLEFT", frame, "TOPLEFT", PAD + iconHorizontalOffset, -PAD + iconVerticalOffset)
+	elseif groupIndex == 2 then
+		indicatorFrame:SetPoint("TOP", frame, "TOP", 0 + iconHorizontalOffset, -PAD + iconVerticalOffset)
+	elseif groupIndex == 3 then
+		indicatorFrame:SetPoint("TOPRIGHT", frame, "TOPRIGHT", -PAD + iconHorizontalOffset, -PAD + iconVerticalOffset)
+	elseif groupIndex == 4 then
+		indicatorFrame:SetPoint("LEFT", frame, "LEFT", PAD + iconHorizontalOffset, 0 + iconVerticalOffset + powerBarVertOffset/2)
+	elseif groupIndex == 5 then
+		indicatorFrame:SetPoint("CENTER", frame, "CENTER", 0 + iconHorizontalOffset, 0 + iconVerticalOffset + powerBarVertOffset/2)
+	elseif groupIndex == 6 then
+		indicatorFrame:SetPoint("RIGHT", frame, "RIGHT", -PAD + iconHorizontalOffset, 0 + iconVerticalOffset + powerBarVertOffset/2)
+	elseif groupIndex == 7 then
+		indicatorFrame:SetPoint("BOTTOMLEFT", frame, "BOTTOMLEFT", PAD + iconHorizontalOffset, PAD + iconVerticalOffset + powerBarVertOffset)
+	elseif groupIndex == 8 then
+		indicatorFrame:SetPoint("BOTTOM", frame, "BOTTOM", 0 + iconHorizontalOffset, PAD + iconVerticalOffset + powerBarVertOffset)
+	elseif groupIndex == 9 then
+		indicatorFrame:SetPoint("BOTTOMRIGHT", frame, "BOTTOMRIGHT", -PAD + iconHorizontalOffset, PAD + iconVerticalOffset + powerBarVertOffset)
+	end
+end
+
+function SetDebug(shouldActivate)
+	EnhancedRaidFrames.debug = shouldActivate
+
+	if shouldActivate then
+		canDispelMagic = true
+		canDispelCurse = true
+		canDispelDisease = true
+		canDispelPoison = true
+	else
+		EnhancedRaidFrames:InitDispels()
+	end
+end
+
+function SetIsGhost(shouldActivate)
+	TryEnableDebugOnDemand(shouldActivate)
+
+	for k,v in pairs(unitStates) do
+		unitStates[k].isGhost = shouldActivate
+	end
+end
+
+function SetIsDead(shouldActivate)
+	TryEnableDebugOnDemand(shouldActivate)
+
+	for k,v in pairs(unitStates) do
+		unitStates[k].isDead = shouldActivate
+	end
+end
+
+function SetHasMagic(shouldActivate)
+	TryEnableDebugOnDemand(shouldActivate)
+
+	for k,v in pairs(unitStates) do
+		unitStates[k].hasMagic = shouldActivate
+	end
+end
+
+function SetHasPoison(shouldActivate)
+	TryEnableDebugOnDemand(shouldActivate)
+
+	for k,v in pairs(unitStates) do
+		unitStates[k].hasPoison = shouldActivate
+	end
+end
+
+function SetHasDisease(shouldActivate)
+	TryEnableDebugOnDemand(shouldActivate)
+
+	for k,v in pairs(unitStates) do
+		unitStates[k].hasDisease = shouldActivate
+	end
+end
+
+function SetHasCurse(shouldActivate)
+	TryEnableDebugOnDemand(shouldActivate)
+
+	for k,v in pairs(unitStates) do
+		unitStates[k].hasCurse = shouldActivate
+	end
+end
+
+function TryEnableDebugOnDemand(shouldActivate)
+	if shouldActivate then
+		SetDebug(true)
+	end
+end
+
+function EnhancedRaidFrames:UpdateUnitState(frame)
+	local unit = frame.unit
+	if unitStates[unit] == nil then
+		unitStates[unit] = {}
+	end
+
+	local unitState = unitStates[unit]
+	if not self.debug then
+		unitState.isDead = UnitIsDead(unit)
+		unitState.isGhost = UnitIsGhost(unit)
+	end
+
+	local healthBarColor = nil
+	local backgroundColor = nil
+
+	if unitState.isGhost then
+		healthBarColor = self.DEFAULT_HEALTHBAR_COLOR
+		backgroundColor = self.GHOST_COLOR
+	elseif unitState.isDead then
+		healthBarColor = self.DEFAULT_HEALTHBAR_COLOR
+		backgroundColor = self.DEAD_COLOR
+	elseif unitState.hasMagic and (canDispelMagic or self:CanDispelType(dispels.magicPet, true)) then
+		healthBarColor = self.BLUE_COLOR
+		backgroundColor = self.DEFAULT_BACKGROUND_COLOR
+	elseif unitState.hasCurse and canDispelCurse then
+		healthBarColor = self.PURPLE_COLOR
+		backgroundColor = self.DEFAULT_BACKGROUND_COLOR
+	elseif unitState.hasDisease and canDispelDisease then
+		healthBarColor = self.BROWN_COLOR
+		backgroundColor = self.DEFAULT_BACKGROUND_COLOR
+	elseif unitState.hasPoison and canDispelPoison then
+		healthBarColor = self.GREEN_COLOR
+		backgroundColor = self.DEFAULT_BACKGROUND_COLOR
+	else
+		healthBarColor = self.DEFAULT_HEALTHBAR_COLOR
+		backgroundColor = self.DEFAULT_BACKGROUND_COLOR
+	end
+
+	local frameName = frame:GetName()
+	local healthBar = _G[frameName .. "HealthBar"]
+
+	healthBar:SetStatusBarColor(healthBarColor:GetRGB())
+	healthBar.background:SetColorTexture(backgroundColor:GetRGBA())
+end
+
+function tprint (tbl, indent)
+  if not indent then indent = 0 end
+  local toprint = string.rep(" ", indent) .. "{\r\n"
+  indent = indent + 2
+  for k, v in pairs(tbl) do
+    toprint = toprint .. string.rep(" ", indent)
+    if (type(k) == "number") then
+      toprint = toprint .. "[" .. k .. "] = "
+    elseif (type(k) == "string") then
+      toprint = toprint  .. k ..  "= "
+    end
+    if (type(v) == "number") then
+      toprint = toprint .. v .. ",\r\n"
+    elseif (type(v) == "string") then
+      toprint = toprint .. "\"" .. v .. "\",\r\n"
+    elseif (type(v) == "table") then
+      toprint = toprint .. tprint(v, indent + 2) .. ",\r\n"
+    else
+      toprint = toprint .. "\"" .. tostring(v) .. "\",\r\n"
+    end
+  end
+  toprint = toprint .. string.rep(" ", indent-2) .. "}"
+  return toprint
+end
+
+
 -- process a single indicator and apply visuals
-function EnhancedRaidFrames:ProcessIndicator(indicatorFrame, unit)
+function EnhancedRaidFrames:ProcessIndicator(indicatorFrame, frame, auraNames, groupIndex)
+	local unit = frame.unit
 	local i = indicatorFrame.position
 
-	local foundAura, icon, count, duration, expirationTime, debuffType, castBy, auraIndex, auraType, _
+	local slotId, foundAura, icon, count, duration, expirationTime, debuffType, castByPlayer, isHarmful, auraIndex
 
 	--reset auraIndex and auraType for tooltip
 	indicatorFrame.auraIndex = nil
-	indicatorFrame.auraType = nil
+	indicatorFrame.isHarmful = nil
 
 	-- if we only are to show the indicator on me, then don't bother if I'm not the unit
 	if self.db.profile[i].meOnly then
@@ -206,25 +749,33 @@ function EnhancedRaidFrames:ProcessIndicator(indicatorFrame, unit)
 	--- parse each aura and find the information of each ---
 	--------------------------------------------------------
 
-	for _, auraName in pairs(self.auraStrings[i]) do
+	for k, v in pairs(auraNames) do
+		local auraName = auraNames[k]
+
 		--if there's no auraName (i.e. the user never specified anything to go in this spot), stop here there's no need to keep going
 		if not auraName then
 			break
 		end
 
 		-- query the available information for a given indicator and aura
-		foundAura, icon, count, duration, expirationTime, debuffType, castBy, auraIndex, auraType = self:QueryAuraInfo(auraName, unit)
+		foundAura, icon, count, duration, expirationTime, debuffType, sourceUnit, isHarmful, auraIndex = self:QueryAuraInfo(auraName, unit)
+		slotId = k
+		castByPlayer = sourceUnit == "player"
 
-		-- add spell icon info to cache in case we need it later on
-		if icon and not self.iconCache[auraName] then
-			EnhancedRaidFrames.iconCache[auraName] = icon
-		end
 
-		-- when tracking multiple things, this determines "where" we stop in the list
-		-- if we find the aura, we can stop querying down the list
-		-- we want to stop only when castBy == "player" if we are tracking "mine only"
-		if foundAura and (not self.db.profile[i].mineOnly or (self.db.profile[i].mineOnly and castBy == "player")) then
-			break
+		if not hasThisAuraAlreadyBeenUsed then
+			-- add spell icon info to cache in case we need it later on
+			if icon and not self.iconCache[auraName] then
+				EnhancedRaidFrames.iconCache[auraName] = icon
+			end
+
+			-- when tracking multiple things, this determines "where" we stop in the list
+			-- if we find the aura, we can stop querying down the list
+			-- we want to stop only when castBy == "player" if we are tracking "mine only"
+			if foundAura and (not self.db.profile[i].mineOnly or (self.db.profile[i].mineOnly and castByPlayer)) then
+				frame.ERFIndicators[groupIndex].numVisibleAuras = frame.ERFIndicators[groupIndex].numVisibleAuras + 1
+				break
+			end
 		end
 	end
 
@@ -232,15 +783,25 @@ function EnhancedRaidFrames:ProcessIndicator(indicatorFrame, unit)
 	------- output visuals to the indicator frame --------
 	------------------------------------------------------
 
+	if not foundAura then
+		indicatorFrame:Hide() --hide the frame
+		--if no aura is found and we're not showing missing, clear animations and hide the frame
+		CooldownFrame_Clear(indicatorFrame.Cooldown)
+		ActionButton_HideOverlayGlow(indicatorFrame)
+		return
+	end
+
+	auraNames[slotId] = nil
+
 	-- if we find the spell and we don't only want to show when it is missing
-	if foundAura and UnitIsConnected(unit) and not self.db.profile[i].missingOnly and (not self.db.profile[i].mineOnly or (self.db.profile[i].mineOnly and castBy == "player")) then
+	if foundAura and UnitIsConnected(unit) and not self.db.profile[i].missingOnly and (not self.db.profile[i].mineOnly or (self.db.profile[i].mineOnly and castByPlayer)) then
 
 		-- calculate remainingTime and round down, this is how the game seems to do it
 		local remainingTime = floor(expirationTime - GetTime())
 
 		-- set auraIndex and auraType for tooltip
 		indicatorFrame.auraIndex = auraIndex
-		indicatorFrame.auraType = auraType
+		indicatorFrame.isHarmful = isHarmful
 
 		---------------------------------
 		--- process icon to show
@@ -251,21 +812,18 @@ function EnhancedRaidFrames:ProcessIndicator(indicatorFrame, unit)
 			indicatorFrame.Icon:SetAlpha(self.db.profile[i].indicatorAlpha)
 		else
 			--set color of custom texture
-			indicatorFrame.Icon:SetColorTexture(
-					self.db.profile[i].indicatorColor.r,
-					self.db.profile[i].indicatorColor.g,
-					self.db.profile[i].indicatorColor.b,
-					self.db.profile[i].indicatorColor.a)
+			local indicatorColor = self.db.profile[i].indicatorColor
+			indicatorFrame.Icon:SetColorTexture(indicatorColor.r, indicatorColor.g, indicatorColor.b, indicatorColor.a)
 
 			-- determine if we should change the background color from the default (player set color)
-			if self.db.profile[i].colorIndicatorByDebuff and debuffType then -- Color by debuff type
-				if debuffType == "poison" then
+			if self.db.profile[i].colorIndicatorByDebuff and isHarmful and debuffType then -- Color by debuff type
+				if debuffType == "Poison" then
 					indicatorFrame.Icon:SetColorTexture(self.GREEN_COLOR:GetRGB())
-				elseif debuffType == "curse" then
+				elseif debuffType == "Curse" then
 					indicatorFrame.Icon:SetColorTexture(self.PURPLE_COLOR:GetRGB())
-				elseif debuffType == "disease" then
+				elseif debuffType == "Disease" then
 					indicatorFrame.Icon:SetColorTexture(self.BROWN_COLOR:GetRGB())
-				elseif debuffType == "magic" then
+				elseif debuffType == "Magic" then
 					indicatorFrame.Icon:SetColorTexture(self.BLUE_COLOR:GetRGB())
 				end
 			end
@@ -281,34 +839,28 @@ function EnhancedRaidFrames:ProcessIndicator(indicatorFrame, unit)
 		---------------------------------
 		--- process text to show
 		---------------------------------
-		if self.db.profile[i].showText ~= "none" then
-			local formattedTime = ""
+		local formattedTime = ""
+
+		-- determine the formatted time string
+		if self.db.profile[i].showDuration and remainingTime then
+			if remainingTime > 60 then
+				formattedTime = string.format("%.0f", remainingTime/60).."m" -- Show minutes without seconds
+			elseif remainingTime >= 0 then
+				formattedTime = string.format("%.0f", remainingTime) -- Show seconds without decimals
+			end
+		end
+
+		indicatorFrame.Text:SetText(formattedTime)
+
+		if self.db.profile[i].showStacks then
 			local formattedCount = ""
 
-			-- determine the formatted time string
-			if remainingTime and (self.db.profile[i].showText == "stack+countdown" or self.db.profile[i].showText == "countdown") then
-				if remainingTime > 60 then
-					formattedTime = string.format("%.0f", remainingTime/60).."m" -- Show minutes without seconds
-				elseif remainingTime >= 0 then
-					formattedTime = string.format("%.0f", remainingTime) -- Show seconds without decimals
-				end
-			end
-
 			-- determine the formatted stack string
-			if count and count > 0 and (self.db.profile[i].showText == "stack+countdown" or self.db.profile[i].showText == "stack") then
+			if count and count > 0 then
 				formattedCount = count
 			end
 
-			-- determine the final output string concatenation
-			if formattedTime ~= "" and formattedCount ~= "" then
-				indicatorFrame.Text:SetText(formattedCount .. "-" .. formattedTime) --append both values together with a hyphen separating
-			elseif formattedCount ~= "" then
-				indicatorFrame.Text:SetText(formattedCount) --show just the count
-			elseif formattedTime ~= "" then
-				indicatorFrame.Text:SetText(formattedTime) --show just the time remaining
-			end
-		else
-			indicatorFrame.Text:SetText("")
+			indicatorFrame.stacksText:SetText(formattedCount)
 		end
 
 		---------------------------------
@@ -321,15 +873,15 @@ function EnhancedRaidFrames:ProcessIndicator(indicatorFrame, unit)
 				self.db.profile[i].textColor.b,
 				self.db.profile[i].textColor.a)
 
-		if self.db.profile[i].colorTextByDebuff and debuffType then -- Color by debuff type
-			if debuffType == "curse" then
-				indicatorFrame.Text:SetTextColor(0.64, 0.19, 0.79, 1)
-			elseif debuffType == "disease" then
-				indicatorFrame.Text:SetTextColor(0.78, 0.61, 0.43, 1)
-			elseif debuffType == "magic" then
-				indicatorFrame.Text:SetTextColor(0, 0.44, 0.87, 1)
-			elseif debuffType == "poison" then
-				indicatorFrame.Text:SetTextColor(0.67, 0.83, 0.45, 1)
+		if self.db.profile[i].colorTextByDebuff and isHarmful and debuffType then -- Color by debuff type
+			if debuffType == "Curse" then
+				indicatorFrame.Text:SetTextColor(self.PURPLE_COLOR:GetRGB())
+			elseif debuffType == "Disease" then
+				indicatorFrame.Text:SetTextColor(self.BROWN_COLOR:GetRGB())
+			elseif debuffType == "Magic" then
+				indicatorFrame.Text:SetTextColor(self.BLUE_COLOR:GetRGB())
+			elseif debuffType == "Poison" then
+				indicatorFrame.Text:SetTextColor(self.GREEN_COLOR:GetRGB())
 			end
 		end
 		if self.db.profile[i].colorTextByTime then -- Color by remaining time
@@ -388,22 +940,19 @@ function EnhancedRaidFrames:ProcessIndicator(indicatorFrame, unit)
 		end
 
 		indicatorFrame:Show() --show the frame
-
-	else
-		indicatorFrame:Hide() --hide the frame
-		--if no aura is found and we're not showing missing, clear animations and hide the frame
-		CooldownFrame_Clear(indicatorFrame.Cooldown)
-		ActionButton_HideOverlayGlow(indicatorFrame)
 	end
 end
 
 --process the text and icon for an indicator and return these values
 --this function returns foundAura, icon, count, duration, expirationTime, debuffType, castBy, auraIndex, auraType
 function EnhancedRaidFrames:QueryAuraInfo(auraName, unit)
+	local auraSpellId = tonumber(auraName)
+
 	-- Check if the aura exist on the unit
-	for _,v in pairs(unitAuras[unit]) do --loop through list of auras
-		if (tonumber(auraName) and v.spellID == tonumber(auraName)) or v.auraName == auraName or (v.auraType == "debuff" and v.debuffType == auraName) then
-			return true, v.icon, v.count, v.duration, v.expirationTime, v.debuffType, v.castBy, v.auraIndex, v.auraType
+	local auras = unitAuras[unit]
+	for k, v in pairs(auras) do --loop through list of auras
+		if auraSpellId and v.spellId == auraSpellId or v.name == auraName then
+				return true, v.icon, v.applications, v.duration, v.expirationTime, v.dispelName, v.sourceUnit, v.isHarmful, v.index
 		end
 	end
 
@@ -442,74 +991,56 @@ end
 function EnhancedRaidFrames:UpdateUnitAuras(unit)
 	-- Create or clear out the tables for the unit
 	unitAuras[unit] = {}
+	unitDebuffs[unit] = {}
 
-	-- Get all unit buffs
-	local i = 1
-	while (true) do
-		local auraName, icon, count, duration, expirationTime, castBy, spellID
 
-		if not self.isWoWClassicEra then
-			auraName, icon, count, _, duration, expirationTime, castBy, _, _, spellID = UnitAura(unit, i, "HELPFUL")
-		else
-			auraName, icon, count, _, duration, expirationTime, castBy, _, _, spellID = self.UnitAuraWrapper(unit, i, "HELPFUL") --for wow classic. This is the LibClassicDurations wrapper
+	local slots = { UnitAuraSlots(unit, "HELPFUL") }
+	for i = 2, #slots do
+		local aura = C_UnitAuras.GetAuraDataBySlot(unit, slots[i])
+		if aura then
+			aura.name = string.lower(aura.name)
+			aura.index = i - 1
+			unitAuras[unit][slots[i]] = aura
 		end
-
-		if not spellID then --break the loop once we have no more buffs
-			break
-		end
-
-		--it's important to use the 4th argument in string.find to turn of pattern matching, otherwise things with parentheses in them will fail to be found
-		if auraName and self.allAuras:find(" "..auraName:lower().." ", nil, true) or self.allAuras:find(" "..spellID.." ", nil, true) then -- Only add the spell if we're watching for it
-			local auraTable = {}
-			auraTable.auraType = "buff"
-			auraTable.auraIndex = i
-			auraTable.auraName = auraName:lower()
-			auraTable.icon = icon
-			auraTable.count = count
-			auraTable.duration = duration
-			auraTable.expirationTime = expirationTime
-			auraTable.castBy = castBy
-			auraTable.spellID = spellID
-
-			table.insert(unitAuras[unit], auraTable)
-		end
-		i = i + 1
 	end
 
-	-- Get all unit debuffs
-	i = 1
-	while (true) do
-		local auraName, icon, count, duration, expirationTime, castBy, spellID, debuffType
+	if unitStates[unit] == nil then
+		unitStates[unit] = {}
+	end
 
-		if not self.isWoWClassicEra then
-			auraName, icon, count, debuffType, duration, expirationTime, castBy, _, _, spellID  = UnitAura(unit, i, "HARMFUL")
-		else
-			auraName, icon, count, debuffType, duration, expirationTime, castBy, _, _, spellID  = self.UnitAuraWrapper(unit, i, "HARMFUL") --for wow classic. This is the LibClassicDurations wrapper
-		end
+	local unitState = unitStates[unit];
+	local hasCurse = false
+	local hasDisease = false
+	local hasMagic = false
+	local hasPoison = false
+	slots = { UnitAuraSlots(unit, "HARMFUL") }
+	for i = 2, #slots do
+		local aura = C_UnitAuras.GetAuraDataBySlot(unit, slots[i])
+		if aura then
+			aura.name = string.lower(aura.name)
+			aura.index = i - 1
+			unitAuras[unit][slots[i]] = aura
+			unitDebuffs[unit][slots[i]] = aura
 
-		if not spellID then --break the loop once we have no more buffs
-			break
-		end
-
-		--it's important to use the 4th argument in string.find to turn off pattern matching, otherwise things with parentheses in them will fail to be found
-		if auraName and self.allAuras:find(" "..auraName:lower().." ", nil, true) or self.allAuras:find(" "..spellID.." ", nil, true) or (debuffType and self.allAuras:find(" "..debuffType:lower().." ", nil, true)) then -- Only add the spell if we're watching for it
-			local auraTable = {}
-			auraTable.auraType = "debuff"
-			auraTable.auraIndex = i
-			auraTable.auraName = auraName:lower()
-			auraTable.icon = icon
-			auraTable.count = count
-			if debuffType then
-				auraTable.debuffType = debuffType:lower()
+			if aura.dispelName then
+				if not hasCurse and aura.dispelName == "Curse" then
+					hasCurse = true
+				elseif not hasDisease and aura.dispelName == "Disease" then
+					hasDisease = true
+				elseif not hasMagic and aura.dispelName == "Magic" then
+					hasMagic = true
+				elseif not hasPoison and aura.dispelName == "Poison" then
+					hasPoison = true
+				end
 			end
-			auraTable.duration = duration
-			auraTable.expirationTime = expirationTime
-			auraTable.castBy = castBy
-			auraTable.spellID = spellID
-
-			table.insert(unitAuras[unit], auraTable)
 		end
-		i = i + 1
+	end
+
+	if not self.debug then
+		unitState.hasCurse = hasCurse;
+		unitState.hasDisease = hasDisease;
+		unitState.hasMagic = hasMagic;
+		unitState.hasPoison = hasPoison;
 	end
 end
 
@@ -524,16 +1055,16 @@ function EnhancedRaidFrames:Tooltip_OnEnter(indicatorFrame)
 	end
 
 	local frame = indicatorFrame:GetParent() --this is the parent raid frame that holds all the indicatorFrames
-
 	-- Set the tooltip
 	if indicatorFrame.auraIndex and indicatorFrame.Icon:GetTexture() then -- -1 is the pvp icon, no tooltip for that
 		-- Set the buff/debuff as tooltip and anchor to the cursor
 		GameTooltip:SetOwner(UIParent, self.db.profile[i].tooltipLocation)
-		if indicatorFrame.auraType == "buff" then
-			GameTooltip:SetUnitAura(frame.unit, indicatorFrame.auraIndex, "HELPFUL")
-		else
-			GameTooltip:SetUnitAura(frame.unit, indicatorFrame.auraIndex, "HARMFUL")
+		local filter = "HELPFUL"
+		if indicatorFrame.isHarmful then
+			filter = "HARMFUL"
 		end
+
+		GameTooltip:SetUnitAura(frame.unit, indicatorFrame.auraIndex, filter)
 	else
 		--causes the tooltip to reset to the "default" tooltip which is usually information about the character
 		if frame then

--- a/EnhancedRaidFrames.lua
+++ b/EnhancedRaidFrames.lua
@@ -28,10 +28,14 @@ EnhancedRaidFrames.NORMAL_COLOR = NORMAL_FONT_COLOR or CreateColor(1.0, 0.82, 0.
 EnhancedRaidFrames.WHITE_COLOR = WHITE_FONT_COLOR or CreateColor(1.0, 1.0, 1.0) --default game white color for text
 EnhancedRaidFrames.RED_COLOR = DIM_RED_FONT_COLOR or CreateColor(0.8, 0.1, 0.1) --solid red color
 EnhancedRaidFrames.YELLOW_COLOR = DARKYELLOW_FONT_COLOR or CreateColor(1.0, 0.82, 0.0) --solid yellow color
-EnhancedRaidFrames.GREEN_COLOR = CreateColor(0.6627, 0.8235, 0.4431) --poison text color
-EnhancedRaidFrames.PURPLE_COLOR = CreateColor(0.6392, 0.1882, 0.7882) --curse text color
-EnhancedRaidFrames.BROWN_COLOR = CreateColor(0.7804, 0.6118, 0.4314) --disease text color
-EnhancedRaidFrames.BLUE_COLOR = CreateColor(0.0, 0.4392, 0.8706) --magic text color
+EnhancedRaidFrames.GREEN_COLOR = CreateColor(0.0, 0.6, 0.0) --poison text color
+EnhancedRaidFrames.PURPLE_COLOR = CreateColor(0.6, 0.0, 1.0) --curse text color
+EnhancedRaidFrames.BROWN_COLOR = CreateColor(0.6, 0.4, 0.0) --disease text color
+EnhancedRaidFrames.BLUE_COLOR = CreateColor(0.2, 0.6, 1.0) --magic text color
+EnhancedRaidFrames.DEFAULT_HEALTHBAR_COLOR = CreateColor(0.4, 0.8, 0.0)
+EnhancedRaidFrames.DEFAULT_BACKGROUND_COLOR = CreateColor(0.12, 0.12, 0.12, 0.3)
+EnhancedRaidFrames.DEAD_COLOR = CreateColor(0.1, 0.1, 0.1, 0.85)
+EnhancedRaidFrames.GHOST_COLOR = CreateColor(0.8, 0.8, 0.8, 0.3)
 
 -------------------------------------------------------------------------
 -------------------------------------------------------------------------
@@ -56,6 +60,22 @@ end
 function EnhancedRaidFrames:OnEnable()
 	--start a repeating timer to updated every frame every 0.8sec to make sure the the countdown timer stays accurate
 	self.updateTimer = self:ScheduleRepeatingTimer("UpdateAllFrames", 0.5) --this is so countdown text is smooth
+	self:InitDispels()
+
+	-- Do I really need to create a frame to register to player spec? Feels dumb.
+	local ERF = CreateFrame("Frame", "ERF")
+	ERF:RegisterEvent("PLAYER_SPECIALIZATION_CHANGED")
+	ERF:RegisterEvent("TRAIT_CONFIG_UPDATED")
+	self:HookScript(ERF, "OnEvent", function(...)
+		 local event = select(2, ...)
+		 if event == "TRAIT_CONFIG_UPDATED" then -- Changed talents but not spec
+			 self:InitDispels()
+		 end
+
+		 if event == "PLAYER_SPECIALIZATION_CHANGED" and select(3, ...) == "player" then
+			 self:InitDispels()
+		 end
+  end)
 
 	--hook our UpdateIndicators function onto the default CompactUnitFrame_UpdateAuras function. The payload of the original function carries the identity of the frame needing updating
 	self:SecureHook("CompactUnitFrame_UpdateAuras", function(frame) self:UpdateIndicators(frame) end)

--- a/GUI/IndicatorConfigPanel.lua
+++ b/GUI/IndicatorConfigPanel.lua
@@ -7,11 +7,23 @@ local EnhancedRaidFrames = addonTable.EnhancedRaidFrames
 
 local L = LibStub("AceLocale-3.0"):GetLocale("EnhancedRaidFrames")
 
-local POSITIONS = { [1] = L["Top left"], [2] = L["Top Center"], [3] = L["Top Right"],
-					[4] = L["Middle Left"], [5] = L["Middle Center"], [6] = L["Middle Right"],
-					[7] = L["Bottom Left"], [8] = L["Bottom Center"], [9] = L["Bottom Right"]}
+local POSITIONS = {
+	[1] = L["Top left"],
+	[2] = L["Top Center"],
+	[3] = L["Top Right"],
+	[4] = L["Middle Left"],
+	[5] = L["Middle Center"],
+	[6] = L["Middle Right"],
+	[7] = L["Bottom Left"],
+	[8] = L["Bottom Center"],
+	[9] = L["Bottom Right"]
+}
 
-
+local GROWTH_DIRECTIONS = {
+	[1] = L["Left"],
+	[2] = L["Centered"],
+	[3] = L["Right"],
+}
 -------------------------------------------------------------------------
 -------------------------------------------------------------------------
 
@@ -138,6 +150,65 @@ function EnhancedRaidFrames:CreateIndicatorOptions()
 						end,
 						width = THIRD_WIDTH,
 						order = 4,
+					},
+					indicatorHorizontalOffset = {
+						type = "range",
+						name = L["numIcons"],
+						desc = L["numIcons_desc"],
+						min = 1,
+						max = 4,
+						step = 1,
+						get = function() return self.db.profile[i].numIcons end,
+						set = function(_, value)
+							self.db.profile[i].numIcons = value
+							self:RefreshConfig()
+						end,
+						width = THIRD_WIDTH,
+						order = 6,
+					},
+					growthDirection = {
+						type = "select",
+						name = L["growthDirection"],
+						desc = L["growthDirection_desc"],
+						values = GROWTH_DIRECTIONS,
+						get = function() return self.db.profile[i].growthDirection end,
+						set = function(_, value)
+							self.db.profile[i].growthDirection = value
+							self:RefreshConfig()
+						end,
+						disabled = function () return self.db.profile[i].numIcons <= 1 end,
+						width = THIRD_WIDTH,
+						order = 7,
+					},
+					showGeneralDebuffs = {
+						type = "toggle",
+						name = L["showGeneralDebuffs"],
+						desc = L["showGeneralDebuffs_desc"],
+						descStyle = "inline",
+						get = function()
+							return self.db.profile[i].showGeneralDebuffs
+						end,
+						set = function(_, value)
+							self.db.profile[i].showGeneralDebuffs = value
+							self:RefreshConfig()
+						end,
+						width = THIRD_WIDTH,
+						order = 8,
+					},
+					showGeneralDebuffs = {
+						type = "toggle",
+						name = L["disableInRaid"],
+						desc = L["disableInRaid_desc"],
+						descStyle = "inline",
+						get = function()
+							return self.db.profile[i].disableInRaid
+						end,
+						set = function(_, value)
+							self.db.profile[i].disableInRaid = value
+							self:RefreshConfig()
+						end,
+						width = THIRD_WIDTH,
+						order = 8,
 					},
 					-------------------------------------------------
 					tooltipOptions = {
@@ -405,23 +476,35 @@ function EnhancedRaidFrames:CreateIndicatorOptions()
 						name = L["General"],
 						order = 1,
 					},
-					showText = {
-						type = "select",
-						name = L["Show Text"],
-						desc = L["showText_desc"],
-						style = "dropdown",
-						values = {["stack"] = L["Stack Size"], ["countdown"] = L["Countdown"],
-								  ["stack+countdown"] = L["Stack Size"].." + "..L["Countdown"], ["none"] = L["None"]},
-						sorting = {[1] = "stack", [2] = "countdown", [3] = "stack+countdown", [4] = "none"},
+					showDuration = {
+						type = "toggle",
+						name = L["showDuration"],
+						desc = L["showDuration_desc"],
+						descStyle = "inline",
 						get = function()
-							return self.db.profile[i].showText
+							return self.db.profile[i].showDuration
 						end,
 						set = function(_, value)
-							self.db.profile[i].showText = value
+							self.db.profile[i].showDuration = value
 							self:RefreshConfig()
 						end,
 						width = THIRD_WIDTH,
 						order = 2,
+					},
+					showStacks = {
+						type = "toggle",
+						name = L["showStacks"],
+						desc = L["showStacks_desc"],
+						descStyle = "inline",
+						get = function()
+							return self.db.profile[i].showStacks
+						end,
+						set = function(_, value)
+							self.db.profile[i].showStacks = value
+							self:RefreshConfig()
+						end,
+						width = THIRD_WIDTH,
+						order = 3,
 					},
 					textSize = {
 						type = "range",
@@ -443,7 +526,7 @@ function EnhancedRaidFrames:CreateIndicatorOptions()
 							end
 						end,
 						width = THIRD_WIDTH,
-						order = 3,
+						order = 4,
 					},
 					-------------------------------------------------
 					colorHeader = {

--- a/Localizations/enUS.lua
+++ b/Localizations/enUS.lua
@@ -56,6 +56,9 @@ L["Bottom Left"] = true
 L["Bottom Center"] = true
 L["Bottom Right"] = true
 
+L["Left"] = true
+L["Centered"] = true
+L["Right"] = true
 
 ----------------------------------------------------
 ------------------- General Panel ------------------
@@ -148,6 +151,18 @@ L["Visibility and Behavior"] = true
 L["Mine Only"] = true
 L["mineOnly_desc"] = "Only show buffs and debuffs cast by me"
 
+L["numIcons"] = "Number of Icons"
+L["numIcons_desc"] = "Number of Icons if using \"Display All\""
+
+L["growthDirection"] = "Growth Direction"
+L["growthDirection_desc"] = "Growth Direction of Display All"
+
+L["showGeneralDebuffs"] = "Show General Debuffs"
+L["showGeneralDebuffs_desc"] = "Only show general debuffs, this will make the aura watch list act as a blacklist."
+
+L["disableInRaid"] = "Disable In Raid"
+L["disableInRaid_desc"] = "Disable this entire indicator while in a group larger than 5."
+
 L["Show On Me Only"] = true
 L["meOnly_desc"] = "Only only show this indicator on myself"
 
@@ -183,6 +198,12 @@ L["indicatorColor_desc1"] = "The solid color used for the indicator when not sho
 L["indicatorColor_desc2"] = "unless augmented by other color options"
 
 L["Text"] = true
+
+L["showDuration"] = true
+L["showDuration_desc"] = "Show duration for the auras on this indicator."
+
+L["showStacks"] = true
+L["showStacks_desc"] = "Show stacks for the auras on this indicator."
 
 L["Show Text"] = true
 L["showText_desc"] = "The text to show on the indicator frame"


### PR DESCRIPTION
Feature summary:
 * Indicator groups that can grow from 1 - 4 auras depending on user settings per indicator group.
 * Separate stacks text on each aura into a separate FontString in the upper right corner.
 * Color HealthBarStatusColor depending on dispelable debuff types (You can't tweak these colors yet)
 * Color HealthBarBackground depending on Alive/Dead/Ghost (You can't tweak these colors yet)
 * Add the ability to have a general debuffs aura group which will show any debuff sorted from shortest duration to longest duration. The aura names that the user enters for which aura to track acts as a blacklist for this group rather than a whitelist (this is not obvious in the UI though)
 * Choose if an indicator group should be disabled in raids (i.e: I use this on my group which tracks personal offensive CDs such as combustion and more, I don't need to see that in raids, but it's nice to see in M+).
 * Add some debug features that can be run from the chat in-game: PrintSupportedDispels(), SetIsGhost(), SetIsDead(), SetHasCurse(), SetHasMagic(), SetHasDisease(), SetHasPoison() and SetDebug() to turn all of it off at once.