### PR TITLE
Add additional custom Range

### DIFF
--- a/DatabaseDefaults.lua
+++ b/DatabaseDefaults.lua
@@ -27,7 +27,7 @@ function EnhancedRaidFrames:CreateDefaults()
 
 		--Out-of-Range Options
 		customRangeCheck = false,
-		customRange = 30,
+		customRange = 40,
 		rangeAlpha = 0.55,
 
 		---Raid Icon Settings

--- a/DatabaseDefaults.lua
+++ b/DatabaseDefaults.lua
@@ -27,7 +27,7 @@ function EnhancedRaidFrames:CreateDefaults()
 
 		--Out-of-Range Options
 		customRangeCheck = false,
-		customRange = 40,
+		customRange = 30,
 		rangeAlpha = 0.55,
 
 		---Raid Icon Settings

--- a/GUI/GeneralConfigPanel.lua
+++ b/GUI/GeneralConfigPanel.lua
@@ -173,7 +173,7 @@ function EnhancedRaidFrames:CreateGeneralOptions()
 				type = "select",
 				name = L["Select a Custom Distance"],
 				desc = L["customRangeCheck_desc"],
-				values = { [5] = "Melee", [10] = "10 yards", [20] = "20 yards", [30] = "30 yards", [35] = "35 yards"},
+				values = { [5] = "Melee", [10] = "10 yards", [20] = "20 yards", [30] = "30 yards", [35] = "35 yards", [40] = "40 yards"},
 				get = function() return self.db.profile.customRange end,
 				set = function(_, value)
 					self.db.profile.customRange = value


### PR DESCRIPTION
Solves issue #98 

This is small but it lets people set their max range to 40 yards.  Since 10.1 there have been some issues (I'm not sure if its from this addon or just from the game) with the out of range distance being set to the incorrect value.