### PR TITLE
Added 25 yard Custom Range

### DIFF
--- a/GUI/GeneralConfigPanel.lua
+++ b/GUI/GeneralConfigPanel.lua
@@ -170,7 +170,7 @@ function EnhancedRaidFrames:CreateGeneralOptions()
 				type = "select",
 				name = L["Select a Custom Distance"],
 				desc = L["customRangeCheck_desc"],
-				values = { [5] = "Melee", [10] = "10 yards", [20] = "20 yards", [30] = "30 yards", [35] = "35 yards", [40] = "40 yards"},
+				values = { [5] = "Melee", [10] = "10 yards", [20] = "20 yards", [25] = "25 yards", [30] = "30 yards", [35] = "35 yards", [40] = "40 yards"},
 				get = function() return self.db.profile.customRange end,
 				set = function(_, value)
 					self.db.profile.customRange = value


### PR DESCRIPTION
Added a 25 yard range option, after really wishing I had it when playing with Augmentation and trying to find people in range of my buffs (especially Prescience).