### PR TITLE
Add "dispel" for debuffs that player can dispel

### DIFF
--- a/Modules/AuraIndicators.lua
+++ b/Modules/AuraIndicators.lua
@@ -250,7 +250,8 @@ function EnhancedRaidFrames:FindActiveAndTrackedAura(indicatorFrame)
 		for _, aura in pairs(parentFrame.ERF_unitAuras) do
 			-- Check if the aura matches our auraString
 			if aura.name == auraIdentifier or (tonumber(auraIdentifier) and aura.spellId == tonumber(auraIdentifier))
-					or (aura.isHarmful and aura.dispelName == auraIdentifier) then
+					or (aura.isHarmful and aura.dispelName == auraIdentifier)
+					or (aura.isHarmful and aura.isRaid and "dispel" == auraIdentifier) then
 				-- Check if we should only show our own auras
 				if not self.db.profile["indicator-" .. i].mineOnly
 						or (self.db.profile["indicator-" .. i].mineOnly and aura.sourceUnit == "player") then

--- a/Modules/AuraListeners.lua
+++ b/Modules/AuraListeners.lua
@@ -174,7 +174,8 @@ function EnhancedRaidFrames:addToAuraTable(parentFrame, auraData)
 	if self.allAuras:find(" " .. auraData.name:lower() .. " ", 1, true)
 			or self.allAuras:find(auraData.spellId, 1, true)
 			-- Check if the aura is a debuff, and if it's a dispellable debuff check if we're tracking the wildcard of that debuff type
-			or (auraData.isHarmful and auraData.dispelName and self.allAuras:find(auraData.dispelName:lower(), 1, true)) then
+			or (auraData.isHarmful and auraData.dispelName and self.allAuras:find(auraData.dispelName:lower(), 1, true))
+			or (auraData.isHarmful and auraData.isRaid and self.allAuras:find("dispel", 1, true)) then
 
 		-- Lowercase the aura name for consistency
 		auraData.name = auraData.name:lower()


### PR DESCRIPTION
This lets you use the word "dispel" as an aura name to display auras you can dispel.

Edit: retail only, UnitAura() doesn't return isRaid you'd have to do a separate call with 'HARMFUL RAID'.