### PR TITLE
Fix bleed colour reference

### DIFF
--- a/Modules/AuraIndicators.lua
+++ b/Modules/AuraIndicators.lua
@@ -530,7 +530,7 @@ function EnhancedRaidFrames:UpdateIndicatorColor(indicatorFrame, remainingTime)
 				indicatorFrame.Icon:SetColorTexture(self.BLUE_COLOR:GetRGB())
 				return
 			elseif thisAura.dispelName == "bleed" then
-				indicatorFrame.Icon:SetColorTexture(self.BLOOD_RED_COLOR:GetRGB())
+				indicatorFrame.Icon:SetColorTexture(self.PINK_COLOR:GetRGB())
 			end
 		end
 	end


### PR DESCRIPTION
When setting indicators to show colour's only a lua error occurs as bleeds are set as BLOOD_RED_COLOR. Globals.lua define the color as PINK_COLOR for bleeds. 